### PR TITLE
Treat DATE the same way the at command does, i.e., specifying an earl…

### DIFF
--- a/screen-at
+++ b/screen-at
@@ -6,10 +6,15 @@
 _scheduled="${1:?No date/time supplied!}"
 _screen_name="${2:?No screen name supplied!}"
 
-_future_date="$(date -d "${_scheduled}" +'%s')"
-_now="$(date +'%s')"
-_later="$(( ${_future_date} - ${_now} ))"
-_when="$(date -d "${_scheduled}" +'%Y-%m-%d %T')"
+_now="$(date +%s)"  # Get current time sooner rather than later.
+_future_date="$(date -d "${_scheduled}" +%s)"
+if [[ _future_date -lt _now ]] ; then
+  echo WARNING: Scheduling for ${_scheduled} tomorrow.
+  _scheduled="$(date -d tomorrow +%F) $(date -d "${_scheduled}" +%T)"
+  _future_date=$(date -d "${_scheduled}" +%s)
+fi
+_later="$((_future_date - _now))"
+_when="$(date -d "${_scheduled}" +'%F %T')"
 
 _args=("${@}")
 _cmd=("${_args[@]:2}")


### PR DESCRIPTION
…ier time will schedule screen to run at that time tomorrow.

---
name: Pull Request
about: Template for general Pull Request
title: ''
labels: ''
assignees: ''
---



Body of this message may include MarkDown formatted content as well as most of the things covered within GitHub's [help][gh_help_formatting_syntax] on related formatting options available.


**Feature Progress**


- [ ] Feature request #9003 for more cow-bell

- [x] **Fixed** #9004 bug with improper timing

- [x] __Finished__ feature request and closing #9005 for _"Xylophone Solo"_


------


> Mentions


@S0AndS0 two out of three ain't half bad, still not sure about the Solo though...


------


> Co-authors


Co-authored-by: name <name@examle.com>
Co-authored-by: another-name <another-name@examle.com>



[gh_help_formatting_syntax]: https://help.github.com/en/articles/basic-writing-and-formatting-syntax#referencing-issues-and-pull-requests
